### PR TITLE
SN + QuickInstall

### DIFF
--- a/root/socialnet/im.php
+++ b/root/socialnet/im.php
@@ -684,10 +684,11 @@ if (!class_exists('socialnet_im'))
 				}
 
 				$in_group = array_diff_key($users, $in_group_added);
+				$array_first = array_shift(array_values($groups));
 				$template->assign_block_vars('sn_im_online_ufg', array(
 					'GID'	 => '0',
 					'NAME'	 => $user->lang['IM_GROUP_UNDECIDED'],
-					'HIDDEN' => $groups[0]['collapse'],
+					'HIDDEN' => $array_first['collapse'],
 					'COUNT'	 => count($in_group),
 					'GROUP'	 => true,
 				));

--- a/root/socialnet/includes/sn_core_comments.php
+++ b/root/socialnet/includes/sn_core_comments.php
@@ -72,12 +72,6 @@ class sn_core_comments
 			return false;
 		}
 
-		$moduleName = $this->_moduleName($module);
-
-		if (!isset($this->modulesName[$moduleName]))
-		{
-			$this->_addModule($moduleName);
-		}
 		$cmt_module = $this->_moduleID($module);
 
 		$sql = "INSERT INTO " . SN_COMMENTS_TABLE . " (cmt_module, cmt_mid, cmt_time, cmt_poster, cmt_text, bbcode_bitfield, bbcode_uid)
@@ -289,6 +283,10 @@ class sn_core_comments
 	function _moduleID($module)
 	{
 		$moduleName = $this->_moduleName($module);
+		if ( !isset($this->modulesName[$moduleName]))
+		{
+			$this->_addModule($module);
+		}
 		return $this->modulesName[$moduleName];
 	}
 


### PR DESCRIPTION
``` code
[phpBB Debug] PHP Notice: in file [ROOT]/socialnet/im.php on line 690: Undefined offset: 0
```

on index.php

phpBB 3.0.11, vanilla installation of QuickInstall with subsilver2, AutoMOD, populated board.

It appeared when installing SN from github, including PR #3.

Also, status & comment fix does not appear to be fixed, what is more, it seems to be broken even more. After posting status, it does not display in feed, instead, php error is displayed:

``` code
[phpBB Debug] PHP Notice: in file on line : : in file on line : 
```

After I reload entire page, it displays, however 2 new php errors occur:

``` code
[phpBB Debug] PHP Notice: in file [ROOT]/socialnet/includes/sn_core_comments.php on line 292:
        Undefined index: userstatus
[phpBB Debug] PHP Notice: in file [ROOT]/socialnet/includes/sn_core_comments.php on line 292:
        Undefined index: userstatus
```

After trying to comment on that status update, it displays comment, however, this php error occurs above it:

``` code
[phpBB Debug] PHP Notice: in file [ROOT]/socialnet/im.php on line 690: Undefined offset: 0
```

But after I reload entire page, those php erros about undefined index of "userstatus" disappear, as well as error above the comment.
