### PR TITLE
Better assumption of branch name in issue2pr.php

### DIFF
--- a/git-tools/issue2pr.php
+++ b/git-tools/issue2pr.php
@@ -110,5 +110,8 @@ function get_branch_name()
 {
 	$head = file_get_contents('../.git/HEAD');
 	$head = explode('/', $head);
-	return $head[2];
+
+	unset($head[0], $head[1]);
+
+	return implode('/', $head);
 }


### PR DESCRIPTION
Currently, if your branch name contains `/`, you are given just part before first `/` in the name. Function `get_branch_name()` should return full branch name, even though it contains `/`.
