### PR TITLE
Add note about limits of curl (used in fetching page for status)

### DIFF
--- a/install_instructions/install_mod.xml
+++ b/install_instructions/install_mod.xml
@@ -16,6 +16,7 @@ Changelog: http://phpbbsocialnetwork.com/viewtopic.php?t=1023
 phpBB Social Network Facebook page: http://www.facebook.com/pages/phpBB-Social-Network/180271885389370
 
 Feel free to ask for support or request more features here http://phpbbsocialnetwork.com/]]></description>
+		<author-notes lang="en"><![CDATA[Please note, that if you want to use "Fetch page" feature (while posting new status), you need to have CURL enabled, safe_mode off and open_basedir not set.]]></author-notes>
 		<author-group>
 			<author>
 				<username phpbbcom="no"><![CDATA[Kamahl19]]></username>


### PR DESCRIPTION
Having safe_mode enabled or open_basedir set, curl results in this error:

```
Warning: curl_setopt_array() [function.curl-setopt-array]: CURLOPT_FOLLOWLOCATION cannot be activated when safe_mode is enabled or an open_basedir is set
```

Therefore it would be fine to include some kind of note about it in author's note or DIY instructions, for users to know that limit.
