### PR TITLE
Improve installation laguage entries

### DIFF
--- a/root/socialnet/install_sn.php
+++ b/root/socialnet/install_sn.php
@@ -30,7 +30,7 @@ if (!file_exists($phpbb_root_path . 'umil/umil_auto.' . $phpEx))
 }
 
 // The name of the mod to be displayed during installation.
-$mod_name = 'Social Network';
+$mod_name = 'phpBB Social Network';
 
 /**
  * The name of the config variable which will hold the currently installed version
@@ -50,8 +50,7 @@ $version_config_name = 'version_socialNet';
  * 'UNINSTALL_' . $mod_name . '_CONFIRM'
  */
 
-$user->add_lang(array('ucp', 'mods/socialnet'));
-$language_file = 'mods/socialnet_acp';
+$language_file = array('ucp', 'mods/socialnet', 'mods/socialnet_acp');
 
 /**
  * Load default constants for extend phpBB constants
@@ -691,15 +690,16 @@ foreach ($previous_versions as $idx => $a_version)
 		$stages = array('UPDATE');
 
 		$umil->display_stages($stages);
-		$template->set_filenames(array('body' => 'message_body.html'));
+		$template->set_filenames(array(
+			'body' => 'message_body.html'
+		));
+
 		$template->assign_vars(array(
 			'S_USER_NOTICE'	 => false,
-			'MESSAGE_TITLE'	 => 'You may update to ' . $a_version,
-			'MESSAGE_TEXT'	 => '</p></div>You have previous version of <strong>phpBB Social Network</strong> installed.<br />
-			You may update to ' . $a_version . ' version first<br />
-			Read install instructions, where you can find the update database script<br />
-			Go to <a href="' . $phpbb_root_path . 'socialnet/update_sn_' . $a_version . '.' . $phpEx . '">update database script</a><div><p>'
+			'MESSAGE_TITLE'	 => 'phpBB Social Network has been already installed',
+			'MESSAGE_TEXT'	 => '</p></div>phpBB Social Network ' . $c_version . ' is already installed on this board.<br />We recommend you to update it to version ' . $a_version . '.<br />Please read update instructions, where you can find the <a href="' . $phpbb_root_path . 'socialnet/update_sn_' . $a_version . '.' . $phpEx . '">update database script</a>.<div><p>'
 		));
+
 		$umil->done();
 	}
 }

--- a/root/socialnet/update_sn_0.7.0.php
+++ b/root/socialnet/update_sn_0.7.0.php
@@ -30,7 +30,7 @@ if (!file_exists($phpbb_root_path . 'umil/umil_auto.' . $phpEx))
 }
 
 // The name of the mod to be displayed during installation.
-$mod_name = 'Social Network - update';
+$mod_name = 'phpBB Social Network update';
 
 /**
  * The name of the config variable which will hold the currently installed version
@@ -49,7 +49,7 @@ $version_config_name = 'version_socialNet';
  * 'UNINSTALL_' . $mod_name
  * 'UNINSTALL_' . $mod_name . '_CONFIRM'
  */
-$language_file = 'mods/socialnet_acp';
+$language_file = array('ucp', 'mods/socialnet', 'mods/socialnet_acp');
 
 /**
  * Load default constants for extend phpBB constants


### PR DESCRIPTION
- MOD name is not `Social Network`, but `phpBB Social Network`.
- `$user->add_lang(array('ucp', 'mods/socialnet'));` should be rewritten to use `$language_file`
- `'MESSAGE_TEXT'` should use only one line.
