### PR TITLE
Improve issue2pr.php so that it can guess issue ID

### DIFF
--- a/git-tools/issue2pr.php
+++ b/git-tools/issue2pr.php
@@ -59,7 +59,7 @@ if ( isset($_GET['username'], $_GET['password'], $_GET['issue_id'], $_GET['branc
 		<form action="" method="GET">
 			Github username: <input type="text" name="username" placeholder="Github username" value="<?php echo `git config user.name`; ?>" /><br />
 			Github password: <input type="password" name="password" placeholder="Github password" /><br />
-			Issue ID: <input type="text" name="issue_id" placeholder="Issue ID" /><br />
+			Issue ID: <input type="text" name="issue_id" placeholder="Issue ID" value="<?php echo get_issue_id(); ?>" /><br />
 			Branch: <input type="text" name="branch" placeholder="Branch" value="<?php echo get_branch_name(); ?>" /><br />
 			<input type="submit" />
 		</form>
@@ -114,4 +114,21 @@ function get_branch_name()
 	unset($head[0], $head[1]);
 
 	return implode('/', $head);
+}
+
+/**
+ * Gets issue ID according to branch name.
+ *
+ * If branch name is in form of "i/[0-9]+", this function will return that number.
+ *
+ * @return string		possible github issue ID
+ */
+function get_issue_id()
+{
+	if ( preg_match('~i/([0-9]+)~', get_branch_name(), $issue_id) )
+	{
+		return $issue_id[1];
+	}
+
+	return '';
 }


### PR DESCRIPTION
To effectivelly develop on github, we create issue for each code change. To issue, we attach code and then it becomes pull request. We should create issue first, and after that create branch with its name (`i/<issue id>`) and send pull request from this branch for other developers to easy check the code, etc.

Thus, branches include issue id that can be easilly guessed by script.

I propose changing issue2pr.php, so that if it can load branch name, and branch name starts with `i/` followed by numbers only, it should type this number into field called "Issue ID".
