### PR TITLE
Link to show your and user's posts is missing in Statistics tab in profile.php

### DIFF
--- a/root/socialnet/profile.php
+++ b/root/socialnet/profile.php
@@ -545,6 +545,7 @@ if (!class_exists('socialnet_profile'))
 				'POSTS'				 => ($member['user_posts']) ? $member['user_posts'] : 0,
 				'WARNINGS'			 => isset($member['user_warnings']) ? $member['user_warnings'] : 0,
 				'S_WARNINGS'		 => ($auth->acl_getf_global('m_') || $auth->acl_get('m_warn')) ? true : false,
+				'U_SEARCH_USER'		 => ($auth->acl_get('u_search')) ? append_sid("{$phpbb_root_path}search.$phpEx", "author_id=$user_id&amp;sr=posts") : '',
 				'U_NOTES'			 => ($user_notes_enabled && $auth->acl_getf_global('m_')) ? append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=notes&amp;mode=user_notes&amp;u=' . $user_id, true, $user->session_id) : '',
 				'U_WARN'			 => ($warn_user_enabled && $auth->acl_get('m_warn')) ? append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=warn&amp;mode=warn_user&amp;u=' . $user_id, true, $user->session_id) : '',
 				'S_USER_NOTES'		 => ($user_notes_enabled) ? true : false,

--- a/root/socialnet/profile.php
+++ b/root/socialnet/profile.php
@@ -545,7 +545,6 @@ if (!class_exists('socialnet_profile'))
 				'POSTS'				 => ($member['user_posts']) ? $member['user_posts'] : 0,
 				'WARNINGS'			 => isset($member['user_warnings']) ? $member['user_warnings'] : 0,
 				'S_WARNINGS'		 => ($auth->acl_getf_global('m_') || $auth->acl_get('m_warn')) ? true : false,
-				'U_SEARCH_USER'		 => ($auth->acl_get('u_search')) ? append_sid("{$phpbb_root_path}search.$phpEx", "author_id=$user_id&amp;sr=posts") : '',
 				'U_NOTES'			 => ($user_notes_enabled && $auth->acl_getf_global('m_')) ? append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=notes&amp;mode=user_notes&amp;u=' . $user_id, true, $user->session_id) : '',
 				'U_WARN'			 => ($warn_user_enabled && $auth->acl_get('m_warn')) ? append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=warn&amp;mode=warn_user&amp;u=' . $user_id, true, $user->session_id) : '',
 				'S_USER_NOTES'		 => ($user_notes_enabled) ? true : false,

--- a/root/styles/prosilver/template/socialnet/user_profile_tab_stats.html
+++ b/root/styles/prosilver/template/socialnet/user_profile_tab_stats.html
@@ -11,7 +11,7 @@
   <!-- ENDIF -->
 	<dt>{L_TOTAL_POSTS}:</dt>
 	<dd>
-		{POSTS}
+		{POSTS} <!-- IF S_DISPLAY_SEARCH -->| <strong><a href="{U_SEARCH_USER}">{L_SEARCH_USER_POSTS}</a> </strong><!-- ENDIF -->
 		<!-- IF POSTS_PCT -->({POSTS_PCT} / {POSTS_DAY})<!-- ENDIF -->
 		<!-- IF POSTS_IN_QUEUE and U_MCP_QUEUE -->(<a href="{U_MCP_QUEUE}">{L_POSTS_IN_QUEUE}</a>)<!-- ELSEIF POSTS_IN_QUEUE -->({L_POSTS_IN_QUEUE})<!-- ENDIF -->
 	</dd>
@@ -19,7 +19,7 @@
   	<dt>{L_ACTIVE_IN_FORUM}:</dt> <dd><!-- IF ACTIVE_FORUM != '' --><strong><a href="{U_ACTIVE_FORUM}">{ACTIVE_FORUM}</a></strong> ({ACTIVE_FORUM_POSTS} / {ACTIVE_FORUM_PCT})<!-- ELSE -->-<!-- ENDIF --></dd>
   	<dt>{L_ACTIVE_IN_TOPIC}:</dt> <dd><!-- IF ACTIVE_TOPIC != '' --><strong><a href="{U_ACTIVE_TOPIC}">{ACTIVE_TOPIC}</a></strong> ({ACTIVE_TOPIC_POSTS} / {ACTIVE_TOPIC_PCT})<!-- ELSE -->-<!-- ENDIF --></dd>
   <!-- ENDIF -->
-	<!-- IF .visitors --><dt>{L_SN_UP_LAST_VISITORS}:</dt> <dd><!-- BEGIN visitors -->{visitors.USERNAME}<!-- IF not visitors.S_LAST_ROW -->, <!-- ENDIF --><!-- END visitors --></dd><!-- ENDIF --> 
+	<!-- IF .visitors --><dt>{L_SN_UP_LAST_VISITORS}:</dt> <dd><!-- BEGIN visitors -->{visitors.USERNAME}<!-- IF not visitors.S_LAST_ROW -->, <!-- ENDIF --><!-- END visitors --></dd><!-- ENDIF -->
 	<dt>{L_SN_UP_PROFILE_VIEWED}:</dt> <dd>{PROFILE_VIEWS}x</dd>
 	{SN_ADDONS_PLACEHOLDER_PROFILE_TAB_STATISTICS_CONTENT}
 </dl>


### PR DESCRIPTION
In label "Total posts" after total number of your or user's posts, in common viewprofile page, there is a link titled with "Show your posts" if you are on your profile and "Search user's posts" if you are on other's profile. This is, however, missing in profile.php. It should be added there.

http://phpbbsocialnetwork.com/viewtopic.php?f=62&t=4205
