### PR TITLE
JavaScript compiler && IE8 and lower error

### DIFF
--- a/root/socialnet/js/m.profile.js
+++ b/root/socialnet/js/m.profile.js
@@ -74,7 +74,7 @@
 							        templates : {
 							            wrapper : _.template('<div class="sn-us-mentions-input-box"></div>'),
 							            autocompleteList : _.template('<div class="sn-us-mentions-autocomplete-list"></div>'),
-							            mentionsOverlay : _.template('<div class="sn-us-mentions"><div></div></div>'),
+							            mentionsOverlay : _.template('<div class="sn-us-mentions"><div></div></div>')
 							        },
 							        onDataRequest : function(mode, query, callback) {
 								        $.getJSON($.sn.us.url, {

--- a/root/socialnet/js/m.userstatus.js
+++ b/root/socialnet/js/m.userstatus.js
@@ -504,7 +504,7 @@
 			        templates : {
 			            wrapper : _.template('<div class="sn-us-mentions-input-box"></div>'),
 			            autocompleteList : _.template('<div class="sn-us-mentions-autocomplete-list"></div>'),
-			            mentionsOverlay : _.template('<div class="sn-us-mentions"><div></div></div>'),
+			            mentionsOverlay : _.template('<div class="sn-us-mentions"><div></div></div>')
 			        },
 			        onDataRequest : function(mode, query, callback) {
 				        $.getJSON($.sn.us.url, {


### PR DESCRIPTION
JavaScript compiler report warning.
IE8 and lower may report error.
###### Wrong

``` js
var = {a:1,b:2,}
```
###### Correct

``` js
var = {a:1,b:2}
```
## 
#### `CZ`

Standardni problem Internet Exploreru.
**Chybne**

``` js
var = {a:1,b:2,}
```

**Spravne**

``` js
var = {a:1,b:2}
```
