### PR TITLE
Correct logic in passing $format in snFunctions::date_format()

### DIFF
--- a/root/socialnet/includes/functions.php
+++ b/root/socialnet/includes/functions.php
@@ -832,7 +832,7 @@ class snFunctions
 			case 'date':
 
 				$formatUser = trim(preg_replace('/[' . $timeChars . ']([ ,.:-\\\|]|$)/s', '', $user->data['user_dateformat']));
-				if ($format == false || $formatUser != '')
+				if ($format == false && $formatUser != '')
 				{
 					$format = $formatUser;
 				}
@@ -842,7 +842,7 @@ class snFunctions
 			case 'time':
 
 				$formatUser = trim(preg_replace('/[^' . $timeChars . ']([ ,.:-\\\|]|$)/s', '', $user->data['user_dateformat']));
-				if ($format == false || $formatUser != '')
+				if ($format == false && $formatUser != '')
 				{
 					$format = $formatUser;
 				}


### PR DESCRIPTION
Currently we use

```
if ($format == false || $formatUser != '')
```

but it should be:

```
if ($format == false && $formatUser != '')
```
