### PR TITLE
Minimum time to check for new IMs option in ACP is set to 1 by default

### DIFF
--- a/git-tools/update_database_dev.php
+++ b/git-tools/update_database_dev.php
@@ -667,8 +667,14 @@ $versions = array(
 		),
 
 	),
-	
+
 	'0.7.1'	 => array(
+	),
+
+	'0.7.2-dev1'	=> array(
+		'custom'			 => array(
+			'phpbbSN_sanatize_im_checkTime_min',
+		),
 	),
 );
 
@@ -678,6 +684,37 @@ $umil->run_actions($action, $versions, $version_config_name);
 
 exit( "The database was updated successfully!\n" ); // to display this message also after developer makes pull
 
+/*
+ * custom functions
+ */
+function phpbbSN_sanatize_im_checkTime_min($action, $version)
+{
+	global $db;
+
+	if ($action == 'update')
+	{
+		$sql = 'SELECT config_value
+				FROM ' . SN_CONFIG_TABLE . '
+				WHERE config_name = "im_checkTime_min"';
+		$result = $db->sql_query($sql);
+		$im_checkTime_min = $db->sql_fetchfield('config_value');
+
+		if ($im_checkTime_min == 1)
+		{
+			$db->sql_query('UPDATE ' . SN_CONFIG_TABLE . ' SET config_value = "2" WHERE config_name = "im_checkTime_min"');
+
+			return 'Social Network::IM check time minimum was set to 2';
+		}
+		else
+		{
+			return 'Social Network::IM check time minimum untouched';
+		}
+	}
+	else
+	{
+		return 'Social Network::IM check time minimum untouched';
+	}
+}
 
 /*
  * console-related functions

--- a/root/socialnet/install_sn.php
+++ b/root/socialnet/install_sn.php
@@ -665,8 +665,14 @@ $versions = array(
 		),
 
 	),
-	
+
 	'0.7.1'	 => array(
+	),
+
+	'0.7.2'	=> array(
+		'custom'			 => array(
+			'phpbbSN_sanatize_im_checkTime_min',
+		),
 	),
 );
 
@@ -712,6 +718,33 @@ foreach ($previous_versions as $idx => $a_version)
  * @ignore
  */
 include($phpbb_root_path . 'umil/umil_auto.' . $phpEx);
+
+function phpbbSN_sanatize_im_checkTime_min($action, $version)
+{
+	if ($action == 'update')
+	{
+		$sql = 'SELECT config_value
+				FROM ' . SN_CONFIG_TABLE . '
+				WHERE config_name = "im_checkTime_min"';
+		$result = $db->sql_query($sql);
+		$im_checkTime_min = $db->sql_fetchfield('config_value');
+
+		if ($im_checkTime_min == 1)
+		{
+			$db->sql_query('UPDATE ' . SN_CONFIG_TABLE . ' SET config_value = "2" WHERE config_name = "im_checkTime_min"');
+
+			return 'Social Network::IM check time minimum was set to 2';
+		}
+		else
+		{
+			return 'Social Network::IM check time minimum untouched';
+		}
+	}
+	else
+	{
+		return 'Social Network::IM check time minimum untouched';
+	}
+}
 
 function phpbbSN_smilies_allow($action, $version)
 {


### PR DESCRIPTION
Minimum time to check for new IMs option in ACP is set to 1 by default, while it can be set to 2 at minimum:

```
The provided value for the setting “Minimum” is too low. The minimum acceptable value is 2.
```

This error is displayed even before you submit form.

This option should be set to `2` by default and checked in update script to be updated to `2` if it is set to `1`.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4290
