### PR TITLE
Addon Hook System does not count with inherited templates

### DIFF
--- a/root/socialnet/includes/sn_core_addons.php
+++ b/root/socialnet/includes/sn_core_addons.php
@@ -117,11 +117,6 @@ class sn_core_addons
 			}
 			$addonTemplate = $this->get_template_name($addon['addon_php'], $addon['addon_function'], $addon['ph_script'], $addon['ph_block']);
 
-			if (!file_exists("{$phpbb_root_path}styles/{$user->theme['template_path']}/template/socialnet/addons/{$addonTemplate}"))
-			{
-				continue;
-			}
-
 			include_once("{$phpbb_root_path}socialnet/addons/{$addon['addon_php']}.{$phpEx}");
 
 			$addonClass = new $addon['addon_php']($this->p_master);


### PR DESCRIPTION
If you use inherited template, hook system for addons does not count with it, so it tries to load template files from currently used style, but it should load template files from parent's style.

The problem is at least in sn_core_addons.php at [a line 120](https://github.com/phpBB-Social-Network/phpBB-Social-Network/blob/develop/root/socialnet/includes/sn_core_addons.php#L120).

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4257
