### PR TITLE
Comment boxes of more loaded statuses does not resize on focus

### DIFF
--- a/root/socialnet/js/jquery.elastic.source.js
+++ b/root/socialnet/js/jquery.elastic.source.js
@@ -46,7 +46,7 @@
 				}
 
 				// Elastic only works on non initialized objects
-				if (jQuery(this).attr('data-elastic') === 'elastic') {
+				if (this.dataElastic === 'elastic') {
 					return false;
 				}
 
@@ -160,6 +160,7 @@
 				$textarea.live('update', update);
 				$textarea.live('focusin', update);
 				$textarea.attr('data-newline', defaults.showNewLine);
+				$textarea.dataElastic = 'elastic';
 
 				// Compact textarea on blur
 				$textarea.bind('blur', function(event) {
@@ -177,7 +178,6 @@
 					setTimeout(update, 250);
 				});
 
-				$textarea.attr('data-elastic', 'elastic');
 				// Run update once when elastic is initialized
 				update(true);
 


### PR DESCRIPTION
If you click on comment box, it doubles its height. However, when you load more posts, comment boxes of those loaded statuses does not double its height on focus.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4415
