### PR TITLE
Profile field edit using textarea does not parse HTML entities.

### DIFF
--- a/root/socialnet/js/jquery.editable.js
+++ b/root/socialnet/js/jquery.editable.js
@@ -212,7 +212,7 @@ jQuery(document).ready(function($) {
 							_t_height = 100;
 						}
 						_input = $('<textarea name="editable-' + idx + '" class="' + opts.inputClass + '" style="min-height:22px;max-height:100px"></textarea>').css(opts.cssText);
-						_input.text(obj.edit);
+						_input.html(obj.edit);
 						th.html(_input);
 						$('textarea[name="editable-' + idx + '"]').elastic(false);
 						_position = 0;


### PR DESCRIPTION
Profile fields which use textearea to be edited does not parse HTML entities. It is due to using `.text` instead of `.html`.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4451
