### PR TITLE
Installation on SQLite does not work because of multiple primary key definitions in one table

### DIFF
--- a/root/socialnet/install_sn.php
+++ b/root/socialnet/install_sn.php
@@ -287,7 +287,7 @@ $versions = array(
 					'fms_clean'		 => array('VCHAR:255', ''),
 					'fms_collapse'	 => array('BOOL', 0),
 				),
-				'PRIMARY_KEY'	 => array('user_id', 'fms_clean'),
+				'UNIQUE_KEY'	 => array('user_id', 'fms_clean'),
 				'KEYS'			 => array(
 					'a'	 => array('UNIQUE', array('user_id', 'fms_name')),
 					'b'	 => array('INDEX', array('fms_gid', 'user_id')),
@@ -665,7 +665,7 @@ $versions = array(
 		),
 
 	),
-	
+
 	'0.7.1'	 => array(
 		'permission_add' => array(
 			array('u_sn_notify', true),


### PR DESCRIPTION
Installation on SQLite failed, because of multiple primary key definitions in `<prefix>_sn_fms_groups` table. Second definition should be rewritten to UNIQUE keys.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=2120
