### PR TITLE
Friends with special characters can be dropped to friends group more times

### DIFF
--- a/root/socialnet/js/m.approval.js
+++ b/root/socialnet/js/m.approval.js
@@ -262,7 +262,7 @@
 
 			$('#sn-fms-groupAccordion > div').droppable({
 				drop: function(event, ui) {
-					var $drag = $(this).children('div[title="' + ui.draggable.attr('title').replace(/([ #;&,.+*~\':"!^$[\]()=><|\/@])/g, '\\\\$1') + '"]');
+					var $drag = $(this).children('div[title="' + ui.draggable.attr('title') + '"]');
 					if ($drag.size() > 0) {
 						return;
 					}


### PR DESCRIPTION
If I add an user (with a normal username) in a group more times, he is visualized only a time. Instead, if I add an user (with special characters in username) in a group more times, he is visualized more times until page refresh.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4547
