### PR TITLE
Disable IM for mobile devices

### DIFF
--- a/root/socialnet/js/m.im.js
+++ b/root/socialnet/js/m.im.js
@@ -58,7 +58,7 @@
 				return false;
 			}
 
-			if ($sn.mobileBrowser && Math.min($(window).height(), $(window).width()) < 700 || $(window).width() < 650) {
+			if ($sn.mobileBrowser && Math.min(screen.availHeight, screen.availWidth) <= 720) {
 				$sn.enableModules.im = false;
 			}
 


### PR DESCRIPTION
We zoom enabled, but mobile devices have enabled the IM.
#135

But we want to disable IM for mobile devices.
