### PR TITLE
Weird search result for guests

### DIFF
--- a/root/styles/prosilver/template/socialnet/block_search.html
+++ b/root/styles/prosilver/template/socialnet/block_search.html
@@ -1,4 +1,4 @@
-<!-- IF S_DISPLAY_SEARCH and B_SN_BLOCK_SEARCH_ENABLED -->
+<!-- IF S_DISPLAY_SEARCH and B_SN_BLOCK_SEARCH_ENABLED and S_USER_LOGGED_IN -->
 <form action="{U_SN_AP_SEARCH}" method="post"><div class="sn-ap-search"><input type="text" value="{SN_AP_SEARCH}" name="username" id="sn-ap-searchUsersAutocomplete" maxlength="256" title="{L_SN_AP_SEARCH}"
 class="inputbox sn-ap-searchInput" onclick="if(this.value=='{L_SN_AP_SEARCH}')this.value='';"
 onblur="if(this.value=='')this.value='{L_SN_AP_SEARCH}';" /><input type="image" src="{T_IMAGESET_PATH}/socialnet/ap_search.png" id="search-submit" class="sn-ap-searchImage"


### PR DESCRIPTION
When you are not logged in, you visit activitypage.php and type anything in the searchbox and submit it, it will redirect you to `socialnet/activitypage.php?mode=search` and content of this page is:

> {"user_id":"ANONYMOUS","more":false,"onlineCount":0}

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4649
