### PR TITLE
arg_separator.output is not always accessible

### DIFF
--- a/root/socialnet/install_sn.php
+++ b/root/socialnet/install_sn.php
@@ -947,7 +947,7 @@ if ( !function_exists('http_build_query'))
 	 * @param int Not used in function, just because of compatibility with php5 function
 	 * @return string Returns a URL-encoded string
 	 */
-	function http_build_query($data, $prefix = '', $separator = arg_separator.output, $enc_type = 0)
+	function http_build_query($data, $prefix = '', $separator = '&', $enc_type = 0)
 	{
 		$queryString = '';
 

--- a/root/socialnet/update_sn_0.7.0.php
+++ b/root/socialnet/update_sn_0.7.0.php
@@ -1112,7 +1112,7 @@ if ( !function_exists('http_build_query'))
 	 * @param int Not used in function, just because of compatibility with php5 function
 	 * @return string Returns a URL-encoded string
 	 */
-	function http_build_query($data, $prefix = '', $separator = arg_separator.output, $enc_type = 0)
+	function http_build_query($data, $prefix = '', $separator = '&', $enc_type = 0)
 	{
 		$queryString = '';
 


### PR DESCRIPTION
In our custom function `http_build_query`, we use `arg_separator.output`, but it is not always accessible. It should be replaced by string `'&'`.
