### PR TITLE
Remove unnecessary parametres from logout link in menu block

### DIFF
--- a/root/styles/prosilver/template/socialnet/block_menu.html
+++ b/root/styles/prosilver/template/socialnet/block_menu.html
@@ -49,7 +49,7 @@
 
 		<!-- IF S_USER_LOGGED_IN -->
 			<li class="ui-menu-item">
-				<a href="{U_LOGIN_LOGOUT}&amp;redirect=./activitypage.php"><span class="sn-menu-icon ui-icon ui-icon-power"></span>{L_SN_AP_LOG_OUT}</a>
+				<a href="{U_LOGIN_LOGOUT}"><span class="sn-menu-icon ui-icon ui-icon-power"></span>{L_SN_AP_LOG_OUT}</a>
 			</li>
 		<!-- ENDIF -->
 


### PR DESCRIPTION
For now, logout link in menu block looks like this:
`ucp.php?mode=logout&sid=90e43a7fc3f444857426fa8b45deef22&redirect=./activitypage.php`, but `&redirect=./activitypage.php` part is unnecessary. It should be removed.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4735
