### PR TITLE
IM chatbox does not stop blinking when focused by another than clicking method

### DIFF
--- a/root/socialnet/js/m.im.js
+++ b/root/socialnet/js/m.im.js
@@ -134,7 +134,7 @@
 				useEnter: false
 			});
 
-			$('.sn-im-chatBox').bind('click', function() {
+			$('.sn-im-message').bind('focus', function() {
 				$sn.im._unReadToggle(this);
 			});
 
@@ -468,7 +468,7 @@
 							}
 							if ($(chatBox + ' .sn-im-block').is(':hidden')) {
 								$sn.im._unRead($(chatBox), 1);
-							} else {
+							} else if (!$(chatBox + ' .sn-im-message').is(':focus')) {
 								$sn.im._unReadToggle(chatBox, true);
 							}
 						});


### PR DESCRIPTION
If you have new message, chatbox should stop bliking when you focus on chatbox texarea. This, however, does not work for cases when you focus textarea by another way, than clicking. Also, when focus is already set to a chatbox, it should not start blinking at all.

http://phpbbsocialnetwork.com/viewtopic.php?f=44&t=4738
